### PR TITLE
Do not distinguish between product and openqa issues for now

### DIFF
--- a/nosier
+++ b/nosier
@@ -1,1 +1,1 @@
-nosier -p openqa_review -p tests "tox"
+nosier -p openqa_review -p tests "tox $@"

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -182,7 +182,6 @@ openqa_review_report_arch_template = Template("""
 
 $new_product_issues
 
-
 **Existing Product bugs:**
 
 $existing_product_issues
@@ -194,6 +193,16 @@ $new_openqa_issues
 **Existing openQA-issues:**
 
 $existing_openqa_issues
+
+**TODO: review**
+
+***new issues***
+
+$new_issues
+
+***existing issues***
+
+$existing_issues
 """)
 
 status_badge_str = {
@@ -335,17 +344,21 @@ def generate_arch_report(arch, results, root_url, verbose_test=1):
         verbose_test = min(verbose_test, max(report.keys()))
         return report[verbose_test](k, v)
 
-    new_product_issues = '\n'.join('* %s' % new_issue_report(k, v, verbose_test) for k, v in iteritems(results) if v['state'] == 'NEW_ISSUE')
-    new_product_issues += '\n'
-    new_product_issues += '* soft fails: ' + ', '.join(k for k, v in iteritems(results) if v['state'] == 'NEW_SOFT_ISSUE')
-    existing_product_issues = '* ' + ', '.join(k for k, v in iteritems(results) if v['state'] == 'STILL_FAILING')
+    new_issues = '\n'.join('* %s' % new_issue_report(k, v, verbose_test) for k, v in iteritems(results) if v['state'] == 'NEW_ISSUE')
+    new_issues += '\n'
+    new_issues += '* soft fails: ' + ', '.join(k for k, v in iteritems(results) if v['state'] == 'NEW_SOFT_ISSUE')
+    existing_issues = '* ' + ', '.join(k for k, v in iteritems(results) if v['state'] == 'STILL_FAILING')
     return openqa_review_report_arch_template.substitute({
         'arch': arch,
         'status_badge': status_badge,
-        'new_product_issues': '',  # TODO everything that is 'NEW_ISSUE' should be product issue but if tests have changed content, then probably openqa issues
+        # TODO everything that is 'NEW_ISSUE' should be product issue but if tests have changed content, then probably openqa issues
+        # For now we can just not easily decide
+        'new_issues': new_issues,
+        'existing_issues': existing_issues,
+        'new_openqa_issues': '',
+        'existing_openqa_issues': '',
+        'new_product_issues': '',
         'existing_product_issues': '',
-        'new_openqa_issues': new_product_issues,
-        'existing_openqa_issues': existing_product_issues,
     })
 
 

--- a/tests/report25_T.md
+++ b/tests/report25_T.md
@@ -15,12 +15,21 @@
 
 
 
-
 **Existing Product bugs:**
 
 
 
 **New openQA-issues:**
+
+
+
+**Existing openQA-issues:**
+
+
+
+**TODO: review**
+
+***new issues***
 
 * ***RAID10***: https://openqa.opensuse.org/tests/169785
 * ***autoyast_13.2_gnome***: https://openqa.opensuse.org/tests/169793
@@ -28,7 +37,7 @@
 * ***textmode***: https://openqa.opensuse.org/tests/169827
 * soft fails: upgrade_offline_13.1_allpatterns
 
-**Existing openQA-issues:**
+***existing issues***
 
 * autoupgrade_13.1, cryptlvm, cryptlvm_minimal_x, gcc5, gcc5+allpatterns, textmode+awesome, toolchain_zypper, upgrade_offline_13.1+gcc5_64bit, upgrade_offline_13.2_gcc5
 

--- a/tests/report25_TT.md
+++ b/tests/report25_TT.md
@@ -15,12 +15,21 @@
 
 
 
-
 **Existing Product bugs:**
 
 
 
 **New openQA-issues:**
+
+
+
+**Existing openQA-issues:**
+
+
+
+**TODO: review**
+
+***new issues***
 
 * ***RAID10***: https://openqa.opensuse.org/tests/169785, failed modules:
  * bootloader: https://openqa.opensuse.org/tests/169785/modules/bootloader/steps/2
@@ -36,7 +45,7 @@
 
 * soft fails: upgrade_offline_13.1_allpatterns
 
-**Existing openQA-issues:**
+***existing issues***
 
 * autoupgrade_13.1, cryptlvm, cryptlvm_minimal_x, gcc5, gcc5+allpatterns, textmode+awesome, toolchain_zypper, upgrade_offline_13.1+gcc5_64bit, upgrade_offline_13.2_gcc5
 

--- a/tests/report25_TTT.md
+++ b/tests/report25_TTT.md
@@ -15,12 +15,21 @@
 
 
 
-
 **Existing Product bugs:**
 
 
 
 **New openQA-issues:**
+
+
+
+**Existing openQA-issues:**
+
+
+
+**TODO: review**
+
+***new issues***
 
 * ***RAID10***: https://openqa.opensuse.org/tests/169785 (reference https://openqa.opensuse.org/tests/169590 ), failed modules:
  * bootloader: https://openqa.opensuse.org/tests/169785/modules/bootloader/steps/2 (needles: bootmenu-20141112)
@@ -36,7 +45,7 @@
 
 * soft fails: upgrade_offline_13.1_allpatterns
 
-**Existing openQA-issues:**
+***existing issues***
 
 * autoupgrade_13.1, cryptlvm, cryptlvm_minimal_x, gcc5, gcc5+allpatterns, textmode+awesome, toolchain_zypper, upgrade_offline_13.1+gcc5_64bit, upgrade_offline_13.2_gcc5
 

--- a/tests/report25_terse.md
+++ b/tests/report25_terse.md
@@ -15,12 +15,21 @@
 
 
 
-
 **Existing Product bugs:**
 
 
 
 **New openQA-issues:**
+
+
+
+**Existing openQA-issues:**
+
+
+
+**TODO: review**
+
+***new issues***
 
 * RAID10
 * autoyast_13.2_gnome
@@ -28,7 +37,7 @@
 * textmode
 * soft fails: upgrade_offline_13.1_allpatterns
 
-**Existing openQA-issues:**
+***existing issues***
 
 * autoupgrade_13.1, cryptlvm, cryptlvm_minimal_x, gcc5, gcc5+allpatterns, textmode+awesome, toolchain_zypper, upgrade_offline_13.1+gcc5_64bit, upgrade_offline_13.2_gcc5
 


### PR DESCRIPTION
For openqa_review it is currently not possible to distinguish easily between
a product issue and a openQA issue so better leave the choice to the user.
The proposed workflow is as follows:

 - The reviewer lets openqa_review create a template for a product, e.g. with

    openqa_review --host openqa.suse.de -j Server \
        --against-reviewed last -TTTT > report_server.md

 - The reviewer investigates all issues mentioned under "TODO" and decides if
   they are either "product" or "openQA" issue and moves them to the 
   corresponding block
 - The reviewer does further tuning of the report before publishing