### PR TITLE
Fix insecure ssl warning

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -167,10 +167,7 @@ class Browser(object):
         else:  # pragma: no cover
             absolute_url = url if not url.startswith('/') else urljoin(self.root_url, str(url))
             # TODO this is very slow at times but reading the same url in webbrowser does not take as long
-            # for now we ignore invalid certificates. It is for reading anyway.
-            # Also, requests does not yet have a proper certificate storage, see
-            # http://www.python-requests.org/en/latest/user/advanced/#ca-certificates
-            r = requests.get(absolute_url, verify=False)
+            r = requests.get(absolute_url)
             if r.status_code != 200:
                 msg = "Request to %s was not successful, status code: %s" % (absolute_url, r.status_code)
                 log.info(msg)


### PR DESCRIPTION
python-requests must be installed via RPM to be able to use the suse ca bundle.
Also the suse ca certificate rpm should be installed.
This applies primarily for openqa.suse.de.