### PR TITLE
Change installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@ For more details read the documentation within `openqa_review/openqa_review.py`.
 
 ## Usage
 
-* Install requirements and package, e.g.
+* Install requirements and package, using an isolated Python environment
+  such as [VirtualEnv](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
 
 ```
-sudo pip install -r requirements.txt
-sudo pip install .
+pip install -r requirements.txt
+pip install .
+```
+
+or if you are using openSUSE distribution, it is recommended to use `zypper`,
+e.g.:
+
+```
+zypper in python-openqa_review
 ```
 
 * Call `openqa-review` from PATH, e.g. with `--help`

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "humanfriendly",
         "requests",
         "PyYAML",
+        "certifi",
     ],
     author="Oliver kurz",
     author_email="okurz@suse.com",


### PR DESCRIPTION
The information provided in the `README` is kind of dangerous
for the unexperienced Linux users, since running any command using
`sudo` can cause problems which might do not know how to resolve.
Apart from that, using `pip` and `sudo` is considered as a very
bad practice that probably causes problems in other projects, thus
most people are using this approach only in a isolated machine
(e.g. VM, Docker, etc) and not into their workstation.

Instead of `sudo`, a better approach would be to use `pip` but as a
'normal user', into an isolated environment which is risk-free of
package conflicts. For example, if a user has installed the same
dependency via both `zypper` and `pip`, then it will probably end up
with strange problems. This is why `VirtualEnv` solution is
mentioned in this commit.

Furthermore, it is considered best practice to use the default
way of installing packages, which is the package manager of the
distribution (e.g. zypper) -- given that such packages are available.

As for the rest of the people who would like
to use `pip`, then they will also need to install `certifi`,
otherwise, the `requests` Python module will be unable to find
their SSL certificate, and the connection will be rejected if
the `$host` is using HTTPS (TCP 443) protocol.