### PR TITLE
Remove unused webtests

### DIFF
--- a/call_tests
+++ b/call_tests
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+PYTHONPATH=.:$PYTHONPATH py.test "$@"

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -55,9 +55,8 @@ authentication and only reads the webpage. No harm should be done :-)
  - Human friendly progress notification and wait spinner
  - Accept multiple entries for '--job-group(-urls)'
  - Ensure report entries are in same alphabetical order with OrderedDict
- - tox.ini: Local tests, webtests, doctests, check with flake8
+ - tox.ini: Local tests, doctests, check with flake8
  - Generate version based on git describe
- - tests: Make slow webtests ignorable by marker
  - Add support to parse all job groups
 
 

--- a/pytest_no_webtest
+++ b/pytest_no_webtest
@@ -1,2 +1,0 @@
-#!/bin/sh -e
-PYTHONPATH=.:$PYTHONPATH py.test -m "not webtest" "$@"

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -458,29 +458,3 @@ def test_arch_distinguish():
 
     report = str(openqa_review.generate_report(args))
     assert 'ppc64le' in report
-
-
-@pytest.mark.webtest
-def test_default_returns_valid_markdown_document():
-    args = args_factory()
-    report = openqa_review.generate_report(args)
-    assert '**Common issues:**' in report
-
-
-@pytest.mark.webtest
-def test_single_job_group_with_extended_test_output_returns_valid_markdown_document():
-    args = args_factory()
-    args.job_group_urls = args.host + '/group_overview/25'
-    report = openqa_review.generate_report(args)
-    assert '**Common issues:**' in report
-
-
-@pytest.mark.webtest
-def test_single_job_group_pages_can_be_cached_from_web():
-    args = args_factory()
-    args.job_group_urls = args.host + '/group_overview/25'
-
-    with TemporaryDirectory() as tmp_dir:
-        args.save_dir = tmp_dir
-        report = openqa_review.generate_report(args)
-    assert '**Common issues:**' in report

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ usedevelop = true
 # work. 'py.test --doctest-modules' fails when combined with '--cov' and its
 # individual call with '--cov-append' also did not show success
 commands =
-    py.test --cov=openqa_review -m "not webtest"
+    py.test --cov=openqa_review
 deps = -rrequirements.txt
     pytest
     pytest-cov
@@ -55,19 +55,7 @@ deps = -rrequirements.txt
 
 [testenv]
 commands =
-    py.test {posargs:-m 'not webtest'}
-deps = -rrequirements.txt
-    pytest
-    pytest-mock
-
-[testenv:webtests]
-# This testenv could be called explicitly, e.g. by 'tox -e webtests'.
-# It is not called by default, which is what we want
-commands =
     py.test
 deps = -rrequirements.txt
     pytest
-
-[pytest]
-markers =
-    webtest: relying on network access, slow
+    pytest-mock


### PR DESCRIPTION
With the current testing approach testing against the web interface is
not done with the webtests so they are untested and not necessary.