### PR TITLE
Process poo#0/boo#0/bsc#0 ticket labels

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -602,7 +602,11 @@ class Issue(object):
         if query_issue_status and progress_browser and bugzilla_browser:
             log.debug("Retrieving bug data for %s" % bugref)
             try:
-                if bugref.startswith('poo#'):
+                if self.bugid == 0:
+                    log.debug("#0 ticket id reference found")
+                    self.msg = 'NOTE: boo#0/bsc#0/poo#0 label used, please review. Consider creating progress ticket for the investigation'
+                    return
+                elif bugref.startswith('poo#'):
                     log.debug("Test issue discovered, looking on progress")
                     self.issue_type = 'redmine'
                     self.json = progress_browser.get_json(bugref_href + '.json')['issue']

--- a/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1508%26groupid%3D25
+++ b/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1508%26groupid%3D25
@@ -391,6 +391,7 @@
         </a>
     </span>
 
+
 </td>
 
 
@@ -422,9 +423,9 @@
         </a>
     </span>
 
-             <span id="bug-384333">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+             <span id="bug-0">
+        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=0">
+            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#0"></i>
         </a>
     </span>
 

--- a/tests/tags_labels/report25_bugrefs_build1508.md
+++ b/tests/tags_labels/report25_bugrefs_build1508.md
@@ -11,7 +11,8 @@
 
 **Existing Product bugs:**
 
-* allpatterns, ext4@i586--l2, gnome, minimal+base -> [bsc#822770](https://bugzilla.opensuse.org/show_bug.cgi?id=822770 "Install of grub2-efi failed") (Ticket status: RESOLVED (FOOBAR), prio/severity: P5/Normal, assignee: bazifoo@gmail.com)
+* allpatterns -> [bsc#0](https://bugzilla.opensuse.org/show_bug.cgi?id=0) (NOTE: boo#0/bsc#0/poo#0 label used, please review. Consider creating progress ticket for the investigation)
+* ext4@i586--l2, gnome, minimal+base -> [bsc#822770](https://bugzilla.opensuse.org/show_bug.cgi?id=822770 "Install of grub2-efi failed") (Ticket status: RESOLVED (FOOBAR), prio/severity: P5/Normal, assignee: bazifoo@gmail.com)
 
 
 **New openQA-issues:**


### PR DESCRIPTION
Include #0 ticket references in the report, so not hiding from
reviewers, while fooling ttm.

See https://github.com/okurz/openqa_review/issues/77 and
[poo#35758](https://progress.opensuse.org/issues/35758).

Example output:
```bash
**Date:** 2018-05-11 - 16:10
**Build:** 609.1 (reference 609.1)

---

**Arch:** x86_64
**Status: <span style="color: green;">Green</span>**

**Existing Product bugs:**

* [fake](http://gershwin.arch.suse.de/tests/366 "Failed modules: logpackages") -> [boo#0](https://bugzilla.opensuse.org/show_bug.cgi?id=0) (NOTE: boo#0/bsc#0/poo#0 label used, please review. Consider creating progress ticket for the investigation)
---

```