### PR TITLE
Add hint for custom CA store locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ zypper in python-openqa_review
 openqa-review --help
 ```
 
+If `openqa-review` has to access non public servers which make use of custom
+*Certificate Authorities* (CA's), it can happen that it fails because it can
+not verify the TLS certificate. By setting the environment variable
+`REQUESTS_CA_BUNDLE`, one can supply a custom ca-certificate store to
+`openqa-review` e.g.:
+
+```
+REQUESTS_CA_BUNDLE="/my/custom/ca-bundle.pem" openqa-review
+```
+
 ## Communication
 
 If you have questions, visit me on irc.freenode.net in #opensuse-factory


### PR DESCRIPTION
The python requests module uses the `certifi` CA store by default to verify all TLS requests done by it.
This can cause problems if `openqa-review` has to access resources protected by custom TLS certificates and results in:

```
openqa_review.browser.DownloadError: Request to https://openqa.example.com/group_overview/110.json was not successful after multiple retries, giving up
```