### PR TITLE
Add soft-fails without bugref to openqa report

### DIFF
--- a/tests/tags_labels/:tests:684839
+++ b/tests/tags_labels/:tests:684839
@@ -1,0 +1,20 @@
+<tr>
+    <td class="component">
+        <div>
+            <a href="/tests/684839/modules/zypper_info/steps/1/src">zypper_info</a>
+        </div>
+        <div class="flags">
+        </div>
+    </td>
+    <td class="result resultsoftfailed">
+        soft-failed
+    </td>
+    <td class="links">
+        <div class="links_a">
+            <div class="fa fa-caret-up"></div>
+            <a class="no_hover" data-url="/tests/684839/modules/zypper_info/steps/3" href="#step/zypper_info/3"
+               title="Soft Failed">
+                <span class="resborder resborder_hash(0x9c726c8)">Soft Failed</span>
+            </a></div>
+    </td>
+</tr>

--- a/tests/tags_labels/:tests:684839:file:details-zypper_info.json
+++ b/tests/tags_labels/:tests:684839:file:details-zypper_info.json
@@ -1,0 +1,15 @@
+[
+  {
+    "needles": [],
+    "result": {
+      "screenshot": "zypper_info-3.png",
+      "frametime": [
+        "153.08",
+        "153.12"
+      ],
+      "result": "unk"
+    },
+    "title": "Soft Failed",
+    "text": "zypper_info-4.txt"
+  }
+]

--- a/tests/tags_labels/:tests:684839:file:zypper_info-4.txt
+++ b/tests/tags_labels/:tests:684839:file:zypper_info-4.txt
@@ -1,0 +1,2 @@
+# Soft Failure:
+for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256

--- a/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
+++ b/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
@@ -2846,6 +2846,26 @@
 </td>
 
                     </tr>
+
+                    <tr>
+                        <td class="name">zypper_info</td>
+
+                                <td>-</td>
+
+                                <td>-</td>
+
+                            <td id="res_Gnome-DVD_i586_soft_fail_without_bugref">
+
+             <span id="res-684839">
+                 <a href="/tests/684839">
+                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+                 </a>
+             </span>
+</td>
+
+                                <td>-</td>
+
+                    </tr>
                     <tr>
                         <td class="name"><span title="leap12_minimal_base+gcc5_create_hdd">leap12_minimal_base+gcc5_cr ...</span></td>
 

--- a/tests/tags_labels/report25_T_bugrefs_softfails.md
+++ b/tests/tags_labels/report25_T_bugrefs_softfails.md
@@ -14,6 +14,7 @@
 * [toolchain_zypper](https://openqa.opensuse.org/tests/384324 "Failed modules: install") -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)
 * [toolchain_zypper@bar](https://openqa.opensuse.org/tests/3843245 "Failed modules: install") -> [boo#9315715](https://bugzilla.opensuse.org/show_bug.cgi?id=9315715)
 * soft fails: [create_hdd_textmode](https://openqa.opensuse.org/tests/447901) -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572)
+* soft fails: [soft_fail_without_bugref](https://openqa.opensuse.org/tests/684839) -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256
 
 
 **Existing Product bugs:**


### PR DESCRIPTION
The commit allows soft-fail reference
in test without a valid bugref to be
reported in the generated report.

Related ticket: https://github.com/okurz/openqa_review/issues/76