### PR TITLE
Add request retry on HTTP error 504

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -114,8 +114,8 @@ class Browser(object):
             except requests.exceptions.ConnectionError:
                 log.info("Connection error encountered accessing %s, retrying try %s" % (url, i))
                 continue
-            if r.status_code == 502:
-                log.info("Request to %s failed with status code 502, retrying try %s" % (url, i))
+            if r.status_code in {502, 504}:
+                log.info("Request to %s failed with status code %s, retrying try %s" % (url, r.status_code, i))
                 continue
             if r.status_code != 200:
                 msg = "Request to %s was not successful, status code: %s" % (url, r.status_code)


### PR DESCRIPTION
The commit adds ability for
openqa-review script to retry
connect to the mentioned url
instead of failing while 504
Gateway Timeout Error occurred