### PR TITLE
 Fix reminder comment when issue type is not valid

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -1201,6 +1201,8 @@ def reminder_comment_on_issue(ie, min_days_unchanged=MIN_DAYS_UNCHANGED):
     issue = ie.bug
     if issue.error:
         return
+    if not issue.issue_type:
+        return
     if (datetime.datetime.utcnow() - issue.last_comment).days >= min_days_unchanged:
         f = ie.failures[0]
         comment = openqa_issue_comment.substitute({'name': f['name'], 'url': ie._url(f)}).strip()

--- a/tests/tags_labels/:jsonrpc.cgi%3Fmethod%3DBug.comments%26params%3D%255B%257B%2522ids%2522%253A%2B%255B931572%255D%257D%255D
+++ b/tests/tags_labels/:jsonrpc.cgi%3Fmethod%3DBug.comments%26params%3D%255B%257B%2522ids%2522%253A%2B%255B931572%255D%257D%255D
@@ -1,0 +1,25 @@
+{
+  "error": null,
+  "id": "http://bugzilla.opensuse.org/",
+  "result": {
+    "bugs": {
+      "931572": {
+        "comments": [
+          {
+            "is_private": false,
+            "count": 0,
+            "creator": "john.doe@suse.com",
+            "attachment_id": null,
+            "time": "2015-05-19T23:54:05Z",
+            "bug_id": 931572,
+            "author": "john.doe@suse.com",
+            "text": "User-Agent:       Mozilla/5.0 (X11; Linux x86_64; rv:37.0) Gecko/20100101 Firefox/37.0\nBuild Identifier: \n\nWhen installing using yast one click, a message comes up saying that it cannot access installation media and to check whether or not the server is available and \"Bad media attach point: http://download.opensuse.org/update/13.2/\". I hit skip and then that same message comes right back up, several times.\n\nReproducible: Always\n\n\n\nExpected Results:  \nThe same message should not come up over and over when skip is selected.",
+            "creation_time": "2015-05-19T23:54:05Z",
+            "id": 6378371
+          }
+        ]
+      }
+    },
+    "comments": {}
+  }
+}

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -474,6 +474,7 @@ def test_reminder_comments_on_referenced_bugs_are_posted():
     args.verbose_test = 1
     args.query_issue_status = True
     args.dry_run = True
+    args.include_softfails = True
     report = openqa_review.generate_report(args)
 
     # test double comment prevention code


### PR DESCRIPTION
When openQA issue does not have a valid bugref,
it is added as 'product' issue. Reminder comment
script goes through the 'product' issues and looks
for a last comment. It will fail on  assertion if issue
type is not 'bugzilla'.

The commit resolves the issue by skipping
'product' issues with invalid issue type.