### PR TITLE
Fix report filter for issues with not valid bugref

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -661,7 +661,7 @@ class Issue(object):
     def is_assigned(self):
         """Issue has been assigned."""
         assert self.queried
-        if self.assignee == 'None':
+        if self.assignee in ('None', None):
             return False
         elif "@forge.provo.novell.com" in self.assignee:
             return False
@@ -672,7 +672,7 @@ class Issue(object):
     def is_open(self):
         """Issue is still open."""
         assert self.queried
-        s = self.status.upper()
+        s = (self.status or '').upper()
         if s in ["RESOLVED", "REJECTED", "VERIFIED", "CLOSED"]:
             return False
         else:

--- a/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
@@ -12,6 +12,8 @@
 **New Product bugs:**
 
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571 "no space left on device when upgrading") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
+* soft fails: create_hdd_textmode -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572 "no space left on device when upgrading") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
+* soft fails: soft_fail_without_bugref -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256
 
 
 **Existing openQA-issues:**

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -489,6 +489,7 @@ def test_custom_reports_based_on_issue_status():
     args = bugrefs_test_args_factory()
     args.verbose_test = 1
     args.query_issue_status = True
+    args.include_softfails = True
     # now, try filtering: unassigned
     report = openqa_review.generate_report(args)
     openqa_review.filter_report(report, openqa_review.ie_filters["unassigned"])


### PR DESCRIPTION
The commit adds additional checks for
an issue properties existence in
order to avoid AttributeError.

That happens when issue does not have
a valid bugref and as a consequence it does
not have some attributes, such as status,
assignee.