### PR TITLE
Adapt script to the openQA layout changes

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -500,11 +500,11 @@ def issue_report_link(root_url, f, test_browser=None):
     overview_params = parse_qs(current_build_overview[-1])
     group = overview_params['groupid'][0]
     build = overview_params['build'][0]
-    scenario_div = test_details_page.find(class_='previous').div.div
-    scenario = re.findall('Results for (.*) \(', scenario_div.text)[0]
+    scenario_div = test_details_page.find(class_='next_previous').div.div
+    scenario = re.findall('Next & previous results for (.*) \(', scenario_div.text)[0]
     latest_link = absolute_url(root_url, scenario_div.a)
     module, url, details = get_failed_module_details_for_report(f)
-    previous_results = test_details_page.find(id='previous_results', class_='overview').find_all('tr')[1:]
+    previous_results = test_details_page.find(id='job_next_previous_table', class_='overview').find_all('tr')[1:]
     previous_results_list = [(i.td['id'], {'status': status(i),
                                            'details': get_test_details(i),
                                            'build': i.find(class_='build').text}) for i in previous_results]

--- a/tests/tags_labels/:tests:384325
+++ b/tests/tags_labels/:tests:384325
@@ -612,12 +612,12 @@
 
                 </div>
                 <div role="tabpanel" class="tab-pane" id="previous">
-                    <div class="previous">
+                    <div class="next_previous">
                         <div id="scenario">
-    <div class="h5">Results for <i>opensuse-42.1-Gnome-DVD-i586-ssh-X@i586--l3</i> (<a href="/tests/latest?flavor=Gnome-DVD&amp;version=42.1&amp;test=ssh-X&amp;machine=i586--l3&amp;distri=opensuse&amp;arch=i586">latest job for this scenario</a>)</div>
+    <div class="h5">Next & previous results for <i>opensuse-42.1-Gnome-DVD-i586-ssh-X@i586--l3</i> (<a href="/tests/latest?flavor=Gnome-DVD&amp;version=42.1&amp;test=ssh-X&amp;machine=i586--l3&amp;distri=opensuse&amp;arch=i586">latest job for this scenario</a>)</div>
 </div>
 <div>
-<table id="previous_results" class="overview table table-striped no-wrap" style="width: 100%">
+<table id="job_next_previous_table" class="overview table table-striped no-wrap" style="width: 100%">
     <thead>
         <tr>
             <th class="job">Result</th>

--- a/tests/tags_labels/:tests:447901
+++ b/tests/tags_labels/:tests:447901
@@ -1191,12 +1191,12 @@
                     </div>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="previous">
-                    <div class="previous">
+                    <div class="next_previous">
                         <div id="scenario">
-    <div class="h5">Results for <i>opensuse-Tumbleweed-DVD-x86_64-create_hdd_textmode@64bit</i> (<a href="/tests/latest?distri=opensuse&amp;flavor=DVD&amp;machine=64bit&amp;arch=x86_64&amp;test=create_hdd_textmode&amp;version=Tumbleweed">latest job for this scenario</a>)</div>
+    <div class="h5">Next & previous results for <i>opensuse-Tumbleweed-DVD-x86_64-create_hdd_textmode@64bit</i> (<a href="/tests/latest?distri=opensuse&amp;flavor=DVD&amp;machine=64bit&amp;arch=x86_64&amp;test=create_hdd_textmode&amp;version=Tumbleweed">latest job for this scenario</a>)</div>
 </div>
 <div>
-<table id="previous_results" class="overview table table-striped no-wrap" style="width: 100%">
+<table id="job_next_previous_table" class="overview table table-striped no-wrap" style="width: 100%">
     <thead>
         <tr>
             <th class="job">Result</th>

--- a/tests/tags_labels/report_link_new_issue/:tests:585912
+++ b/tests/tags_labels/report_link_new_issue/:tests:585912
@@ -3636,12 +3636,12 @@
                     </div>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="previous">
-                    <div class="previous">
+                    <div class="next_previous">
                         <div id="scenario">
-    <div class="h5">Results for <i>openSUSE-42.1-Gnome-DVD-arm-gcc5+allpatterns@arm</i> (<a href="/tests/latest?machine=arm&amp;arch=arm&amp;distri=opensuse&amp;flavor=Gnome-DVD&amp;test=gcc5%2Ballpatterns&amp;version=42.1">latest job for this scenario</a>)</div>
+    <div class="h5">Next & previous results for <i>openSUSE-42.1-Gnome-DVD-arm-gcc5+allpatterns@arm</i> (<a href="/tests/latest?machine=arm&amp;arch=arm&amp;distri=opensuse&amp;flavor=Gnome-DVD&amp;test=gcc5%2Ballpatterns&amp;version=42.1">latest job for this scenario</a>)</div>
 </div>
 <div>
-<table id="previous_results" class="overview table table-striped no-wrap" style="width: 100%">
+<table id="job_next_previous_table" class="overview table table-striped no-wrap" style="width: 100%">
     <thead>
         <tr>
             <th class="job">Result</th>


### PR DESCRIPTION
The layout of Results Page in openQA UI was changed in the latest release. The PR adapts openqa_review script to the changes and updates the appropriate tests data accordingly.

I've tested that changes by running script locally with the exact parameters as on production and the report was generated without errors.