### PR TITLE
Format all urls in softfail message using markdown

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -711,8 +711,13 @@ class Issue(object):
             msg = 'Ticket status: %s, prio/severity: %s, assignee: %s' % (status, self.priority, self.assignee)
         else:
             msg = None
+
+        def _format_all_urls_using_markdown(string):
+            url_pattern = r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+            return re.sub(url_pattern, r'[\g<0>](\g<0>)', string)
+
         title_str = ' "%s"' % self.subject.replace(')', '&#41;') if self.subject else ''
-        bugref_str = '[%s](%s%s)' % (self.bugref, self.bugref_href, title_str) if self.bugref_href else self.bugref
+        bugref_str = '[%s](%s%s)' % (self.bugref, self.bugref_href, title_str) if self.bugref_href else _format_all_urls_using_markdown(self.bugref)
         msg_str = ' (%s)' % msg if msg else ''
         return '%s%s' % (bugref_str, msg_str)
 

--- a/tests/tags_labels/:tests:684839:file:zypper_info-4.txt
+++ b/tests/tags_labels/:tests:684839:file:zypper_info-4.txt
@@ -1,2 +1,2 @@
 # Soft Failure:
-for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256
+for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for https://progress.opensuse.org/issues/36256 to be solved, and also http://fate.suse.com/12345

--- a/tests/tags_labels/report25_T_bugrefs_softfails.md
+++ b/tests/tags_labels/report25_T_bugrefs_softfails.md
@@ -14,7 +14,7 @@
 * [toolchain_zypper](https://openqa.opensuse.org/tests/384324 "Failed modules: install") -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)
 * [toolchain_zypper@bar](https://openqa.opensuse.org/tests/3843245 "Failed modules: install") -> [boo#9315715](https://bugzilla.opensuse.org/show_bug.cgi?id=9315715)
 * soft fails: [create_hdd_textmode](https://openqa.opensuse.org/tests/447901) -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572)
-* soft fails: [soft_fail_without_bugref](https://openqa.opensuse.org/tests/684839) -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256
+* soft fails: [soft_fail_without_bugref](https://openqa.opensuse.org/tests/684839) -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for [https://progress.opensuse.org/issues/36256](https://progress.opensuse.org/issues/36256) to be solved, and also [http://fate.suse.com/12345](http://fate.suse.com/12345)
 
 
 **Existing Product bugs:**

--- a/tests/tags_labels/report25_bugrefs_query_issues.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues.md
@@ -14,7 +14,7 @@
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571 "no space left on device when upgrading") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
 * toolchain_zypper@bar -> [boo#9315715](https://bugzilla.opensuse.org/show_bug.cgi?id=9315715) (Ticket not found)
 * soft fails: create_hdd_textmode -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572 "no space left on device when upgrading") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
-* soft fails: soft_fail_without_bugref -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256
+* soft fails: soft_fail_without_bugref -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for [https://progress.opensuse.org/issues/36256](https://progress.opensuse.org/issues/36256) to be solved, and also [http://fate.suse.com/12345](http://fate.suse.com/12345)
 
 
 **Existing Product bugs:**

--- a/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
@@ -13,7 +13,7 @@
 
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571 "no space left on device when upgrading") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
 * soft fails: create_hdd_textmode -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572 "no space left on device when upgrading") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
-* soft fails: soft_fail_without_bugref -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256
+* soft fails: soft_fail_without_bugref -> for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for [https://progress.opensuse.org/issues/36256](https://progress.opensuse.org/issues/36256) to be solved, and also [http://fate.suse.com/12345](http://fate.suse.com/12345)
 
 
 **Existing openQA-issues:**


### PR DESCRIPTION
The PR adds a function, that parses soft fail messages and formats
all found urls using markdown, e.g.` [http://example.com](http://example.com)` 
and the appropriate tests.

It allows to show the urls as links in the report instead of showing them
as a plain text.

**For reviewers:** Just to prevent questions related to the data, that I've updated in the test (`for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for https://progress.opensuse.org/issues/36256 to be solved, and also http://fate.suse.com/12345`).

It contains two links instead of one to cover more cases, such as:
* http and http**s**;
* positioning of the link (in the middle of message and in the end);
* to check that several links, but not only one could be parsed and formatted properly;
* to ensure that most usual links to progress and fate are both covered.