### PR TITLE
Add request retry on HTTP error 503

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -114,7 +114,7 @@ class Browser(object):
             except requests.exceptions.ConnectionError:
                 log.info("Connection error encountered accessing %s, retrying try %s" % (url, i))
                 continue
-            if r.status_code in {502, 504}:
+            if r.status_code in {502, 503, 504}:
                 log.info("Request to %s failed with status code %s, retrying try %s" % (url, r.status_code, i))
                 continue
             if r.status_code != 200:


### PR DESCRIPTION
Some reports failed to be generated due to 503 error, while accessing openQA URLs.

The PR adds an ability to reconnect on 503 error in the same way as it was already made for 502 and 504 errors.