### PR TITLE
Use version compare algo to compare builds

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -109,6 +109,7 @@ from string import Template
 from urllib.parse import quote, unquote, urljoin, urlencode, splitquery, parse_qs
 
 from bs4 import BeautifulSoup
+from pkg_resources import parse_version
 from sortedcontainers import SortedDict
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -451,7 +452,7 @@ def get_build_urls_to_compare(browser, job_group_url, builds='', against_reviewe
 
     finished_builds = find_builds(get_group_result(), running_threshold)
     # find last finished and previous one
-    builds_to_compare = sorted(finished_builds, reverse=True)[0:2]
+    builds_to_compare = sorted(finished_builds, key=parse_version, reverse=True)[0:2]
 
     if builds:
         # User has to be careful here. A page for non-existant builds is always
@@ -462,7 +463,7 @@ def get_build_urls_to_compare(browser, job_group_url, builds='', against_reviewe
         try:
             last_reviewed = find_last_reviewed_build(job_group['comments'])
             log.debug("Comparing specified build %s against last reviewed %s" % (against_reviewed, last_reviewed))
-            build_to_review = max(finished_builds) if against_reviewed == 'last' else against_reviewed
+            build_to_review = builds_to_compare[0] if against_reviewed == 'last' else against_reviewed
             assert len(build_to_review) <= len(last_reviewed) + 1, "build_to_review and last_reviewed differ too much to make sense"
             builds_to_compare = build_to_review, last_reviewed
         except (NameError, AttributeError, IndexError):

--- a/tests/https%3A::openqa.opensuse.org:group_overview:26.json
+++ b/tests/https%3A::openqa.opensuse.org:group_overview:26.json
@@ -9,13 +9,13 @@
 	"max_jobs": 91,
 	"group": {"id": 26, "name": "openSUSE Leap"},
 	"result": {
-		"162.1": {
+		"62.1": {
 			"distri": "opensuse",
 			"version": "15",
 			"reviewed": "",
 			"reviewed_all_passed": "",
-			"escaped_build": "162_1",
-			"escaped_id": "15-162_1",
+			"escaped_build": "62_1",
+			"escaped_id": "15-62_1",
 			"labeled": 0,
 			"oldest": "2016-11-08T16:59:11",
 			"failed": 20,


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/44648

Fixes #111

This will make sure that build 98 will be sorted before 102.